### PR TITLE
Update snp.cpp

### DIFF
--- a/src/eqtlbma/quantgen/snp.cpp
+++ b/src/eqtlbma/quantgen/snp.cpp
@@ -134,11 +134,11 @@ namespace quantgen {
     vector<string> tokens2, tokens3;
     for(size_t i = 0; i < nb_samples; ++i){
       split(*(begin+i), ":", tokens2);
-      if(tokens2[0].find(".") != string::npos) {
+      if(tokens2[1].find(".") != string::npos) {
 	minor_allele_freq = NaN;
       }
       else{
-	split(tokens2[0], "|/", tokens3);
+	split(tokens2[1], "|/", tokens3);
 	genotypes[i] = 0;
 	if(tokens3[0].compare("1") == 0)
 	  genotypes[i] += 1;


### PR DESCRIPTION
We think that these modifications are necessary to comply with the VCF format of the GTEX data (with GT in the 2nd field, the first field is the GL). GL/GT/DS. However, maybe we should check if these will work with all VCF files?
