### PR TITLE
Modified eqtl_bma_bf_parallel.bash to accept summary stats as input

### DIFF
--- a/scripts/eqtlbma_bf_parallel.bash
+++ b/scripts/eqtlbma_bf_parallel.bash
@@ -135,7 +135,7 @@ function parseArgs () {
 	    --scoord) scoord=$2; shift 2;;
 	    --exp) exp=$2; shift 2;;
 	    --fcoord) fcoord=$2; shift 2;;
-	    --inss) inss=true; shift 2;;
+	    --inss) inss=$2; shift 2;;
 	    --anchor) anchor=$2; shift 2;;
 	    --cis) cis=$2; shift 2;;
 	    --out) out=$2; shift 2;;


### PR DESCRIPTION
I'm still unsure if whether this will resolve the problems about requiring genotype and expression data as input. I recognize this has been resolved in the single batch context with eqtl_bma_bf
