### PR TITLE
Fix reference bug when loading non-vcf data bundles

### DIFF
--- a/src/eqtlbma/quantgen/data_loader.hpp
+++ b/src/eqtlbma/quantgen/data_loader.hpp
@@ -129,14 +129,12 @@ namespace quantgen {
   		   const std::string & anchor,
   		   const size_t & radius,
   		   const int & verbose,
-  		   std::map<std::string, Snp> & snp2object,
-  		   std::map<std::string, std::vector<Snp*> > & mChr2VecPtSnps);
+           std::map<std::string, Snp> & snp2object);
   
   void loadSnpInfo(const std::string & snpCoordsFile,
 		   const std::set<std::string> & sSnpsToKeep,
 		   const int & verbose,
-		   std::map<std::string, Snp> & snp2object,
-		   std::map<std::string, std::vector<Snp*> > & mChr2VecPtSnps);
+           std::map<std::string, Snp> & snp2object);
   
   void loadSnpInfo(const std::string & file_snpcoords,
   		   const std::set<std::string> & sSnpsToKeep,
@@ -144,14 +142,14 @@ namespace quantgen {
   		   const std::string & anchor,
   		   const size_t & radius,
   		   const int & verbose,
-  		   std::map<std::string, Snp> & snp2object,
-  		   std::map<std::string, std::vector<Snp*> > & mChr2VecPtSnps);
+           std::map<std::string, Snp> & snp2object);
   
   void loadGenos(
     const std::map<std::string, std::string> & subgroup2genofile,
     const float & min_maf,
     const int & verbose,
-    std::map<std::string, Snp> & snp2object);
+    std::map<std::string, Snp> & snp2object,
+  	std::map<std::string, std::vector<Snp*> > & mChr2VecPtSnps);
   
   void loadListCovarFiles(
     const std::string & file_covarpaths,


### PR DESCRIPTION
Please read the commit message here:

https://github.com/gaow/eqtlbma/commit/2c080acc2ea19c2070d67785caeaa53eb8a36aca

Here is the story: GTEx V6 data is not in VCF format. When analyzing it, GSL SVD crashed on me with a complaint message (gsl: svd.c:286: ERROR: svd of MxN matrix, M<N, is not implemented) so I created this branch and tried to create a toy data to trouble-shoot. Yet the program crashed with segfault on the toy data which led to investigation and thus this patch. Now it works on my toy set but I am not sure if this gets rid of the GSL error (investigating). Creating this pull request because I think this is a critical bug that should best be fixed. 